### PR TITLE
fix dump rules by converting cmdlines to a list

### DIFF
--- a/ananicy.py
+++ b/ananicy.py
@@ -626,7 +626,7 @@ class Ananicy:
             raise Failure(f'Duplicate name "{name}": ')
 
         if (cmdlines := line.get("cmdlines")):
-            cmdlines = set(cmdlines)
+            cmdlines = list(cmdlines)
 
         self.rules[name] = {
             "cmdlines": cmdlines,


### PR DESCRIPTION
Previously, `dump rules` was failing, because a `set` cannot be converted into JSON. Having `cmdlines` as a `list` fixes this problem.