### PR TITLE
Reorganize and extend GCC rule

### DIFF
--- a/ananicy.d/00-default/compilers/g++.rules
+++ b/ananicy.d/00-default/compilers/g++.rules
@@ -1,1 +1,0 @@
-{ "name": "g++", "type": "compiler" }

--- a/ananicy.d/00-default/compilers/gcc.rules
+++ b/ananicy.d/00-default/compilers/gcc.rules
@@ -1,1 +1,19 @@
-{ "name": "gcc", "type": "compiler" }
+# C compilation
+{ "name": "gcc",         "type": "compiler" }
+{ "name": "cc",          "type": "compiler" }
+{ "name": "cc1",         "type": "compiler" }
+{ "name": "c99",         "type": "compiler" }
+{ "name": "c89",         "type": "compiler" }
+
+# C++ compilation
+{ "name": "g++",         "type": "compiler" }
+{ "name": "c++",         "type": "compiler" }
+{ "name": "cpp",         "type": "compiler" }
+{ "name": "cc1plus",     "type": "compiler" }
+
+# linking
+{ "name": "lto1",        "type": "compiler" }
+{ "name": "lto-wrapper", "type": "compiler" }
+
+# other
+{ "name": "collect2",    "type": "compiler" }

--- a/ananicy.d/00-default/compilers/gcc.rules
+++ b/ananicy.d/00-default/compilers/gcc.rules
@@ -17,3 +17,4 @@
 
 # other
 { "name": "collect2",    "type": "compiler" }
+


### PR DESCRIPTION
Hi,
Merged `g++` and `gcc` rule file because they are binaries of same compiler and when you have one, you also have the other.
I don't think it make sense to keep them separate. (I'd open issue about this merge first, but this repo has issues disabled :()
Also, what is more important, I extended rule to cover also `cc1plus` (seen when building from AUR) and other binaries.

