### PR TITLE
Add support for regexps in "name" field

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Support for cmdline in rules added. This is particularly useful for applications
 ```
 This translates to: apply the rule to any process named `java`, that received `freenet.node.NodeStarter` as a command line argument. You can add more than one "cmdlines" in case you want to fine tune your rules.
 
+Support for matching cmd by regexp:
+
+```
+{ "name": "ghc-.*", "name_is_regexp": true, "type": "compiler" }
+```
+
 # Old description
 
 ## Description

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+echo "Test"
+sleep 100
+echo "End sleep"


### PR DESCRIPTION
This is required for handling rules for `ghc-9.6.3` and so on.