### PR TITLE
Add rule for git-annex

### DIFF
--- a/ananicy.d/00-default/git-annex.rules
+++ b/ananicy.d/00-default/git-annex.rules
@@ -1,0 +1,1 @@
+{ "name": "git-annex", "type": "BG_CPUIO" }


### PR DESCRIPTION
Git-annex often has to calculate hashes for many files. Set it to BG_CPUIO so it doesn't hog resources.