### PR TITLE
Add kopia to file-sync rules

### DIFF
--- a/ananicy.d/00-default/file-sync/kopia.rules
+++ b/ananicy.d/00-default/file-sync/kopia.rules
@@ -1,0 +1,2 @@
+# Kopia backup server: https://kopia.io/
+{ "name": "kopia", "type": "file-sync" }


### PR DESCRIPTION
This service is very CPU intensive and uses all threads on the running system when it's running.  With the configured file-sync rule, its impact on the system is reduced massively whenever it starts its regular backup procedures.