### PR TITLE
fix git clone locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ $ sudo make install
 * ![logo](http://www.monitorix.org/imgs/archlinux.png "arch logo") Arch: [AUR/ananicy-git](https://aur.archlinux.org/packages/ananicy-git).
 * Debian/Ubuntu: use [package.sh](https://raw.githubusercontent.com/Nefelim4ag/Ananicy/master/package.sh) in repo
 ```
-$ git clone https://github.com/Nefelim4ag/Ananicy.git
-$ ./Ananicy/package.sh debian
-$ sudo dpkg -i ./Ananicy/ananicy-*.deb
+$ git clone https://github.com/kuche1/miinq-ananicy.git
+$ ./minq-ananicy/package.sh debian
+$ sudo dpkg -i ./minq-ananicy/ananicy-*.deb
 ```
 
 Enable


### PR DESCRIPTION
Fixing git clone locations from previous repositories to avoid wrong git clone locations to build to Debian Based system (Including: Ubuntu and Linux Mint)